### PR TITLE
Module Sync needs GADTs or TypeFamilies with GHC 9.2.5

### DIFF
--- a/lib/Sync.hs
+++ b/lib/Sync.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Sync
   -- (


### PR DESCRIPTION
.../mywork/lib/Sync.hs:122:7: error:
    • Illegal equational constraint NoteCore core ~ NoteRT
      (Use GADTs or TypeFamilies to permit this)
