### PR TITLE
Use XdgConfig instead of XdgData

### DIFF
--- a/lib/Panes/FileMgr.hs
+++ b/lib/Panes/FileMgr.hs
@@ -41,7 +41,7 @@ import qualified Graphics.Vty as Vty
 import           Path ( Path, Abs, File, (</>), parseAbsFile
                       , relfile, reldir, parent, toFilePath )
 import           Path.IO ( createDirIfMissing, doesFileExist
-                         , XdgDirectory(XdgData), getXdgDir )
+                         , XdgDirectory(XdgConfig), getXdgDir )
 
 import           Defs
 import           Defs.JSON ()
@@ -301,9 +301,9 @@ handleFileSaveEvent ev ts =
 
 ensureDefaultProjectFile :: IO (Path Abs File)
 ensureDefaultProjectFile = do
-  dataDir <- getXdgDir XdgData $ Just [reldir|mywork|]
-  createDirIfMissing True dataDir
-  let pFile = dataDir </> [relfile|projects.json|]
+  confDir <- getXdgDir XdgConfig $ Just [reldir|mywork|]
+  createDirIfMissing True confDir
+  let pFile = confDir </> [relfile|projects.json|]
   e <- doesFileExist pFile
   unless e $ BS.writeFile (toFilePath pFile) ""
   return pFile


### PR DESCRIPTION
In the spirit of the original FHS (filesystem hierarchy standard), datadir
is for read-only platform-independent data.
Before this patch, mywork creates projects.json in
~/.local/share/mywork/
which looks just wrong.  ~/.local mostly adheres to the FHS, which means the
share subdir is ment to be read-only.
Since this is configuration data, it should go to
~/.config/mywork/
